### PR TITLE
[bug] Fix initial rendering bug

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -4,6 +4,10 @@
   <component name="FrameworkDetectionExcludesConfiguration">
     <file type="web" url="file://$PROJECT_DIR$" />
   </component>
+  <component name="PWA">
+    <option name="enabled" value="true" />
+    <option name="wasEnabledAtLeastOnce" value="true" />
+  </component>
   <component name="ProjectRootManager" version="2" languageLevel="JDK_11" default="true" project-jdk-name="11" project-jdk-type="JavaSDK" />
   <component name="SwUserDefinedSpecifications">
     <option name="specTypeByUrl">

--- a/src/main/java/com/chriscarini/jetbrains/locchangecountdetector/factory/LOCIconWidgetFactory.java
+++ b/src/main/java/com/chriscarini/jetbrains/locchangecountdetector/factory/LOCIconWidgetFactory.java
@@ -19,15 +19,8 @@ public class LOCIconWidgetFactory implements LOCBaseWidgetFactory {
     }
 
     @Override
-    public @NotNull StatusBarWidget createWidget(@NotNull Project project) {
+    public @NotNull StatusBarWidget getWidget(@NotNull Project project) {
         return new LOCWidgetIcon(project);
     }
-
-//    @Override
-//    public boolean isAvailable(@NotNull Project project) {
-//        // TODO(ChrisCarini) - We could consider showing the icon only if the change size exceeds a certain limit.
-//        return ProjectLevelVcsManager.getInstance(project).hasActiveVcss() && LoCService.getInstance(project).getChangeCount() >= 300;
-//    }
-
 }
 

--- a/src/main/java/com/chriscarini/jetbrains/locchangecountdetector/factory/LOCPerCommitWidgetFactory.java
+++ b/src/main/java/com/chriscarini/jetbrains/locchangecountdetector/factory/LOCPerCommitWidgetFactory.java
@@ -19,9 +19,8 @@ public class LOCPerCommitWidgetFactory implements LOCBaseWidgetFactory {
     }
 
     @Override
-    public @NotNull StatusBarWidget createWidget(@NotNull Project project) {
+    public @NotNull StatusBarWidget getWidget(@NotNull Project project) {
         return new LOCCountWidgetText(project);
     }
-
 }
 

--- a/src/main/java/com/chriscarini/jetbrains/locchangecountdetector/git/GitNumStat.java
+++ b/src/main/java/com/chriscarini/jetbrains/locchangecountdetector/git/GitNumStat.java
@@ -115,5 +115,4 @@ public class GitNumStat {
             return new Pair<>(this.getAddedLines() + this.getDeletedLines(), this.getFilesChanged());
         }
     }
-
 }

--- a/src/main/java/com/chriscarini/jetbrains/locchangecountdetector/git/GitNumStat.java
+++ b/src/main/java/com/chriscarini/jetbrains/locchangecountdetector/git/GitNumStat.java
@@ -1,0 +1,119 @@
+package com.chriscarini.jetbrains.locchangecountdetector.git;
+
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.util.Pair;
+import com.intellij.openapi.vcs.VcsException;
+import git4idea.commands.Git;
+import git4idea.commands.GitCommand;
+import git4idea.commands.GitLineHandler;
+import org.jetbrains.annotations.NonNls;
+import org.jetbrains.annotations.NotNull;
+
+import java.io.File;
+import java.util.List;
+import java.util.Objects;
+
+public class GitNumStat {
+    private final GitCommand myGitCommand;
+
+    public GitNumStat(@NotNull final GitCommand gitCommand) {
+        myGitCommand = gitCommand;
+    }
+
+    /**
+     * Get the `git <command> HEAD --numstat --format=oneline` output for the provided project.
+     *
+     * @param project The project for which to run the command upon.
+     * @return The output from the `git` command
+     * @throws VcsException with message from {@link git4idea.commands.GitCommandResult#getErrorOutputAsJoinedString()}
+     */
+    @NonNls
+    @NotNull
+    private String getGitCommandOutput(@NotNull final Project project) throws VcsException {
+        final String basePath = project.getBasePath();
+        if (basePath == null) {
+            return "0";
+        }
+        final GitLineHandler handler = new GitLineHandler(project, new File(basePath), myGitCommand);
+        handler.setSilent(true);
+        handler.setStdoutSuppressed(true);
+        handler.addParameters("HEAD");
+        //noinspection SpellCheckingInspection
+        handler.addParameters("--numstat");
+        handler.addParameters("--format=oneline");
+        return Git.getInstance().runCommand(handler).getOutputOrThrow();
+    }
+
+    /**
+     * Compute the {@link GitNumStat.Info} for the provided project.
+     *
+     * @param project The project for which to run the command upon.
+     * @return The {@link GitNumStat.Info} object representing the additions, deletions, and count of changed files.
+     */
+    @NotNull
+    public GitNumStat.Info compute(@NotNull final Project project) {
+        int filesChanged = 0;
+        int additions = 0;
+        int deletions = 0;
+
+        final String output;
+
+        try {
+            output = this.getGitCommandOutput(project);
+        } catch (Exception e) {
+            return new Info(0, 0, 0);
+        }
+
+        final List<String> lines = List.of(output.split("\n"));
+        for (final String line : lines) {
+            final List<String> lineSplit = List.of(line.split("\t"));
+            if (lineSplit.size() == 0 || Objects.equals(lineSplit.get(0), "")) {
+                continue;
+            }
+            filesChanged += 1;
+            try {
+                additions += Integer.parseInt(lineSplit.get(0));
+            } catch (NumberFormatException e) {
+                // We are likely trying to parse a git hash, and need to just skip to the next line.
+                continue;
+            }
+            deletions += Integer.parseInt(lineSplit.get(1));
+        }
+
+        return new Info(additions, deletions, filesChanged);
+    }
+
+    public static class Info {
+        private final Integer addedLines;
+        private final Integer deletedLines;
+        private final Integer filesChanged;
+
+        public Info(@NotNull final Integer addedLines, @NotNull final Integer deletedLines, @NotNull final Integer filesChanged) {
+            this.addedLines = addedLines;
+            this.deletedLines = deletedLines;
+            this.filesChanged = filesChanged;
+        }
+
+        public Integer getAddedLines() {
+            return addedLines;
+        }
+
+        public Integer getDeletedLines() {
+            return deletedLines;
+        }
+
+        public Integer getFilesChanged() {
+            return filesChanged;
+        }
+
+        /**
+         * Provides a {@link Pair} object, the first being the summation of added and deleted lines, and the second being the number of files changed.
+         *
+         * @return a {@link Pair} object
+         */
+        public Pair<Integer, Integer> toPair() {
+            return new Pair<>(this.getAddedLines() + this.getDeletedLines(), this.getFilesChanged());
+        }
+    }
+
+}

--- a/src/main/java/com/chriscarini/jetbrains/locchangecountdetector/widget/LOCCountWidgetText.java
+++ b/src/main/java/com/chriscarini/jetbrains/locchangecountdetector/widget/LOCCountWidgetText.java
@@ -1,87 +1,30 @@
 package com.chriscarini.jetbrains.locchangecountdetector.widget;
 
-import com.chriscarini.jetbrains.locchangecountdetector.LoCCOPIcons;
 import com.chriscarini.jetbrains.locchangecountdetector.LoCService;
 import com.chriscarini.jetbrains.locchangecountdetector.Utils;
-import com.chriscarini.jetbrains.locchangecountdetector.messages.Messages;
-import com.intellij.notification.Notification;
-import com.intellij.notification.NotificationGroupManager;
-import com.intellij.notification.NotificationType;
-import com.intellij.notification.impl.NotificationFullContent;
-import com.intellij.openapi.actionSystem.AnAction;
-import com.intellij.openapi.actionSystem.AnActionEvent;
-import com.intellij.openapi.application.ApplicationManager;
-import com.intellij.openapi.fileEditor.FileEditorManagerEvent;
-import com.intellij.openapi.project.DumbAware;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.Disposer;
 import com.intellij.openapi.util.NlsContexts;
-import com.intellij.openapi.vcs.actions.CommonCheckinProjectAction;
-import com.intellij.openapi.vfs.VirtualFileManager;
-import com.intellij.openapi.vfs.newvfs.BulkFileListener;
-import com.intellij.openapi.vfs.newvfs.events.VFileEvent;
-import com.intellij.openapi.wm.StatusBar;
 import com.intellij.openapi.wm.StatusBarWidget;
 import com.intellij.openapi.wm.impl.status.EditorBasedWidget;
 import com.intellij.util.Consumer;
-import com.intellij.util.ui.update.MergingUpdateQueue;
-import com.intellij.util.ui.update.Update;
 import org.jetbrains.annotations.NonNls;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.awt.event.MouseEvent;
-import java.util.List;
 
 public class LOCCountWidgetText extends EditorBasedWidget implements StatusBarWidget, StatusBarWidget.TextPresentation {
 
     public static final String ID = "LoCCounter";
-    public static final String NOTIFICATION_GROUP = "LoCCOPNotification";
-    private MergingUpdateQueue myQueue;
-    @SuppressWarnings("UnstableApiUsage")
-    private @NlsContexts.Label String myText;
-
-    private final LoCService locService;
-    private Notification existingNotification;
 
     public LOCCountWidgetText(@NotNull Project project) {
         super(project);
-        locService = LoCService.getInstance(myProject);
-
-        // Perform an initial update of the text; see Issue #36 for symptoms
-        ApplicationManager.getApplication().invokeLater(this::updateChangeText);
-
-        project.getMessageBus().connect().subscribe(VirtualFileManager.VFS_CHANGES, new BulkFileListener() {
-            @Override
-            public void after(@NotNull List<? extends VFileEvent> events) {
-                boolean fileWasSaved = false;
-
-                // Iterate over all the files and check if any are from save events
-                for (VFileEvent event : events) {
-                    if (event.isFromSave()) {
-                        fileWasSaved = true;
-                        // Exit the for loop once we've found at least one file that was saved.
-                        break;
-                    }
-                }
-
-                // If any files changed, schedule an update
-                if (fileWasSaved) {
-                    ApplicationManager.getApplication().invokeLater(() -> updateChangeText());
-                }
-            }
-        });
     }
 
     @Override
     public @NonNls @NotNull String ID() {
         return ID;
-    }
-
-    @Override
-    public void install(@NotNull StatusBar statusBar) {
-        super.install(statusBar);
-        this.myQueue = new MergingUpdateQueue("PositionPanel", 100, true, null, this);
     }
 
     @Override
@@ -92,7 +35,7 @@ public class LOCCountWidgetText extends EditorBasedWidget implements StatusBarWi
     @SuppressWarnings("UnstableApiUsage")
     @Override
     public @NotNull @NlsContexts.Label String getText() {
-        return this.myText == null ? "" : this.myText;
+        return this.getChangeText();
     }
 
     @Override
@@ -108,7 +51,7 @@ public class LOCCountWidgetText extends EditorBasedWidget implements StatusBarWi
     @SuppressWarnings("UnstableApiUsage")
     @Override
     public @Nullable @NlsContexts.Tooltip String getTooltipText() {
-        return Utils.generateToolTipText(locService);
+        return Utils.generateToolTipText(LoCService.getInstance(myProject));
     }
 
     @Override
@@ -116,101 +59,9 @@ public class LOCCountWidgetText extends EditorBasedWidget implements StatusBarWi
         return null;
     }
 
-    @Override
-    public void selectionChanged(@NotNull FileEditorManagerEvent event) {
-    }
-
-    private void updateChangeText() {
-        locService.computeLoCInfo();
-        myQueue.queue(Update.create(this, () -> {
-            String newText = this.getChangeText();
-            if (newText.equals(myText)) return;
-
-            myText = newText;
-            if (myStatusBar != null) {
-                myStatusBar.updateWidget(ID());
-                myStatusBar.updateWidget(LOCWidgetIcon.ID);
-
-                Integer changeCount = locService.getChangeCount();
-                if (changeCount >= 500) {
-
-                    // Clear any existing notification, the number is likely different.
-                    clearExistingNotification();
-
-                    // TODO(ChrisCarini) - found here: https://www.plugin-dev.com/intellij/general/notifications/#classes
-                    //  Clean this up and see if we can use `NotificationGroupManager` to create this class.
-                    final class MyNotification extends Notification implements NotificationFullContent {
-                        private MyNotification(@NlsContexts.NotificationTitle String title, @NlsContexts.NotificationContent String content, NotificationType type) {
-                            super(NOTIFICATION_GROUP, title, content, type);
-                        }
-                    }
-
-                    final Notification notification = new MyNotification(
-                            Messages.message("loc.count.widget.text.update.change.text.notification.title"),
-                            Messages.message("loc.count.widget.text.update.change.text.notification.content", changeCount),
-                            NotificationType.INFORMATION
-                    );
-                    notification.setIcon(LoCCOPIcons.LoCCOP_Warning);
-                    notification.addAction(new CreateCommitAction(myProject));
-                    notification.notify(myProject);
-                    existingNotification = notification;
-
-//                    NotificationGroupManager.getInstance()
-//                            .getNotificationGroup(NOTIFICATION_GROUP_ID)
-//                            .createNotification(
-//                                    "Large change detected!",
-//                                    wrapHtml(String.format("You have made a change that is %s lines\n<br/>of code. Consider creating a PR.", changeCount)),
-//                                    NotificationType.INFORMATION
-//                            )
-//                            .setIcon(LoCCOPIcons.LoCCOP_Warning)
-//                            .addAction(new CreateCommitAction(myProject))
-//                            .notify(myProject);
-                } else {
-                    // Clear any existing notification, the number is likely different.
-                    clearExistingNotification();
-                }
-            }
-        }));
-    }
-
-    private void clearExistingNotification() {
-        if (existingNotification != null) {
-            existingNotification.expire();
-            existingNotification = null;
-        }
-    }
-
-    private static class CreateCommitAction extends AnAction implements DumbAware {
-        private final Project myProject;
-
-        public CreateCommitAction(@NotNull final Project project) {
-            super(Messages.message("loc.count.widget.text.create.commit.action.text"));
-            this.myProject = project;
-        }
-
-        @Override
-        public void actionPerformed(@NotNull AnActionEvent e) {
-            // Pull up the commit dialog...
-            final CommonCheckinProjectAction f = new CommonCheckinProjectAction();
-            //noinspection UnstableApiUsage
-            f.actionPerformed(e);
-
-
-            // Give a final notification
-            NotificationGroupManager.getInstance()
-                    .getNotificationGroup(NOTIFICATION_GROUP)
-                    .createNotification(
-                            Messages.message("loc.count.widget.text.create.commit.action.notification.title"),
-                            Messages.message("loc.count.widget.text.create.commit.action.notification.content"),
-                            NotificationType.INFORMATION
-                    )
-                    .setIcon(LoCCOPIcons.LoCCOP_OK)
-                    .notify(myProject);
-        }
-    }
-
     @NotNull
     private String getChangeText() {
-        return String.format("%d/%d::%s/%s", locService.getChangeCountInCommit(), locService.getChangeCount(), locService.getFileCountInCommit(), locService.getFileCount());
+        final LoCService service = LoCService.getInstance(myProject);
+        return String.format("%d/%d::%s/%s", service.getChangeCountInCommit(), service.getChangeCount(), service.getFileCountInCommit(), service.getFileCount());
     }
 }

--- a/src/main/java/com/chriscarini/jetbrains/locchangecountdetector/widget/LOCWidgetIcon.java
+++ b/src/main/java/com/chriscarini/jetbrains/locchangecountdetector/widget/LOCWidgetIcon.java
@@ -19,16 +19,13 @@ public class LOCWidgetIcon extends EditorBasedWidget implements StatusBarWidget,
 
     public static final String ID = "LoCIcon";
 
-    private final LoCService locService;
-
     public LOCWidgetIcon(@NotNull Project project) {
         super(project);
-        locService = LoCService.getInstance(this.myProject);
     }
 
     @Override
     public @Nullable Icon getIcon() {
-        final int changeCount = locService.getChangeCount();
+        final int changeCount = LoCService.getInstance(myProject).getChangeCount();
 
         if (changeCount >= 500) {
             return LoCCOPIcons.LoCCOP_Error;
@@ -45,16 +42,16 @@ public class LOCWidgetIcon extends EditorBasedWidget implements StatusBarWidget,
         return ID;
     }
 
+    @SuppressWarnings("UnstableApiUsage")
     @Override
     public @Nullable @NlsContexts.Tooltip String getTooltipText() {
-        return Utils.generateToolTipText(locService);
+        return Utils.generateToolTipText(LoCService.getInstance(myProject));
     }
 
     @Override
     public @Nullable Consumer<MouseEvent> getClickConsumer() {
         return null;
     }
-
 
     @Override
     public @Nullable WidgetPresentation getPresentation() {


### PR DESCRIPTION
# Summary

This change fixes the initial rendering bug (for good, hopefully). It additionally moves logic into more 'logical' places.

# Details

## Bug Details
The initial rendering bug is fixed by changing `LOCBaseWidgetFactory.isAvailable()` method to always return `true`. Previously, we were returning `ProjectLevelVcsManager.getInstance(project).hasActiveVcss()` which would not always return `true` in time for the widget logic initialization.

## Additional Changes

### Widget Registration

To make it easier to update widgets, the `LOCBaseWidgetFactory` interface now has a `registerId()` (static) and `updateAllWidgets()` (static) method - the default behavior of `createWidget()` (implemented from the `StatusBarWidgetFactory` interface) will now register widgets for us.

### Move VFS Change Listener out of widget and into the service

To keep the widgets (UI elements) as slim and simple as possible, the logic for registering VFS change listener (and all associated logic) has been moved out of the text widget (why the text widget, and not the icon widget, well that'd have caused us other issues down the road if we kept this as-is, but never mind that...) and into the service. The associated logic includes the notification triggering and generation logic, along with UI update logic for both widgets (again, side-effects of this would have caused us issues in the future, but we need not worry about that now).

### Move UI update triggering into the LoC computation

In order to keep the UI update triggering logic in a single, non-widget location, the logic has moved into the service. This logic can be further refined in the future (ie, don't call certain parts if not needed), but it should mostly be happening in a background thread and out of the UI thread, so it doesn't cause *any* of the UI to hang, which is optimal.