### PR TITLE
Upgrading IntelliJ to 2022.1

### DIFF
--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -36,8 +36,8 @@ jobs:
         uses: ChrisCarini/intellij-platform-plugin-verifier-action@latest
         with:
           ide-versions: |
-            ideaIC:2021.3
-            ideaIU:2021.3
+            ideaIC:2022.1
+            ideaIU:2022.1
             ideaIC:LATEST-EAP-SNAPSHOT
             ideaIU:LATEST-EAP-SNAPSHOT
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,14 +5,19 @@
 ## [Unreleased]
 
 ### Added
+- Localization for German, Spanish and French (#34)
+- Error Report Submitter to easily open GitHub issues when this plugin has issues (#35, #43)
 
 ### Changed
+- Upgrading IntelliJ to 2022.1
 
 ### Deprecated
 
 ### Removed
 
 ### Fixed
+- Show LoC text widget on project open (#38, #45)
+- Fix LoC computation bug (#44)
 
 ### Security
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,10 +1,11 @@
+# suppress inspection "AlphaUnsortedPropertiesFile" for whole file
 # IntelliJ Platform Artifacts Repositories
 # -> https://www.jetbrains.org/intellij/sdk/docs/reference_guide/intellij_artifacts.html
 
 pluginGroup = com.chriscarini.jetbrains
 pluginName = 'LoC Change Count Detector'
 # SemVer format -> https://semver.org
-pluginVersion = 0.0.1
+pluginVersion = 0.0.2
 
 ### I DO NOT MAKE USE OF SINCE/UNTIL IN THIS PLUGIN.
 ## See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
@@ -14,7 +15,7 @@ pluginVersion = 0.0.1
 
 # Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl
 # See https://jb.gg/intellij-platform-builds-list for available build versions
-pluginVerifierIdeVersions = 2021.3
+pluginVerifierIdeVersions = 2022.1
 
 # IntelliJ Platform Properties -> https://github.com/JetBrains/gradle-intellij-plugin#intellij-platform-properties
 platformType = IC
@@ -22,7 +23,7 @@ platformType = IC
 # and https://www.jetbrains.com/intellij-repository/snapshots/
 # To use/download EAP add '-EAP-SNAPSHOT' to the version, i.e. 'IU-191.6014.8-EAP-SNAPSHOT'
 #        platformVersion = '201.6668.60-EAP-SNAPSHOT'
-platformVersion = 2021.3
+platformVersion = 2022.1
 platformDownloadSources = true
 
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html


### PR DESCRIPTION
Upgrading IntelliJ to 2022.1 in preparation for final dev-testing before releasing for alpha users.