### PR TITLE
Commenting out publish plugin step for the initial release to JetBrains Marketplace.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,11 +53,11 @@ jobs:
         run: |
           ./gradlew patchChangelog --release-note="$CHANGELOG"
 
-      # Publish the plugin to the Marketplace
-      - name: Publish Plugin
-        env:
-          PUBLISH_TOKEN: ${{ secrets.PUBLISH_TOKEN }}
-        run: ./gradlew publishPlugin
+#      # Publish the plugin to the Marketplace
+#      - name: Publish Plugin
+#        env:
+#          PUBLISH_TOKEN: ${{ secrets.PUBLISH_TOKEN }}
+#        run: ./gradlew publishPlugin
 
       # Upload artifact as a release asset
       - name: Upload Release Asset


### PR DESCRIPTION
# Summary

Commenting out publish plugin step for the initial release to JetBrains Marketplace.

# Details

The initial release to JetBrains Marketplace needs to be done locally via the web UI, and not via the gradle task.

Temporarily disabling the task to allow the rest of the workflow to complete upon release.