### PR TITLE
Upgrading IntelliJ from 2022.2.4 to 2022.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Added
 
 ### Changed
+- Upgrading IntelliJ from 2022.2.4 to 2022.3.0
 
 ### Deprecated
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@
 pluginGroup = com.chriscarini.jetbrains
 pluginName = 'LoC Change Count Detector'
 # SemVer format -> https://semver.org
-pluginVersion = 0.0.6
+pluginVersion = 0.1.0
 
 ### I DO NOT MAKE USE OF SINCE/UNTIL IN THIS PLUGIN.
 ## See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
@@ -15,7 +15,7 @@ pluginVersion = 0.0.6
 
 # Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl
 # See https://jb.gg/intellij-platform-builds-list for available build versions
-pluginVerifierIdeVersions = 2022.2.4,LATEST-EAP-SNAPSHOT
+pluginVerifierIdeVersions = 2022.3,LATEST-EAP-SNAPSHOT
 # Failure Levels: https://github.com/JetBrains/gradle-intellij-plugin/blob/master/src/main/kotlin/org/jetbrains/intellij/tasks/RunPluginVerifierTask.kt
 # Exclude `DEPRECATED_API_USAGES` because we use `CommonCheckinProjectAction` which is a JetBrains internal
 # class that implements a class marked to be deprecated.
@@ -27,7 +27,7 @@ platformType = IC
 # and https://www.jetbrains.com/intellij-repository/snapshots/
 # To use/download EAP add '-EAP-SNAPSHOT' to the version, i.e. 'IU-191.6014.8-EAP-SNAPSHOT'
 #        platformVersion = '201.6668.60-EAP-SNAPSHOT'
-platformVersion = 2022.2.4
+platformVersion = 2022.3
 platformDownloadSources = true
 
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html

--- a/gradle.properties
+++ b/gradle.properties
@@ -32,7 +32,7 @@ platformDownloadSources = true
 
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
 # Example: platformPlugins = com.intellij.java, com.jetbrains.php:203.4449.22
-platformPlugins = git4idea
+platformPlugins = Git4Idea
 
 # Java language level used to compile sources and to generate the files for
 # - Java 11 is required since 2020.3

--- a/src/main/java/com/chriscarini/jetbrains/locchangecountdetector/LoCService.java
+++ b/src/main/java/com/chriscarini/jetbrains/locchangecountdetector/LoCService.java
@@ -19,7 +19,7 @@ import com.intellij.openapi.project.Project;
 import com.intellij.openapi.roots.ProjectRootManager;
 import com.intellij.openapi.util.Disposer;
 import com.intellij.openapi.util.Pair;
-import com.intellij.openapi.vcs.actions.CommonCheckinProjectAction;
+import com.intellij.openapi.vcs.actions.commit.CommonCheckinProjectAction;
 import com.intellij.openapi.vfs.VirtualFileManager;
 import com.intellij.openapi.vfs.newvfs.BulkFileListener;
 import com.intellij.openapi.vfs.newvfs.events.VFileEvent;
@@ -169,7 +169,6 @@ public class LoCService implements Disposable {
         public void actionPerformed(@NotNull AnActionEvent e) {
             // Pull up the commit dialog...
             final CommonCheckinProjectAction f = new CommonCheckinProjectAction();
-            //noinspection UnstableApiUsage
             f.actionPerformed(e);
 
             final Consumer<ChangeInfo> callback = ChangeThresholdService.getInstance(myProject).getCreateCommitActionCallback();


### PR DESCRIPTION

# Upgrading IntelliJ from 2022.2.4 to 2022.3.0

You can find the change log here: https://youtrack.jetbrains.com/articles/IDEA-A-2100661406/IntelliJ-IDEA-2022.3-223.7571.182-build-Release-Notes

# What's New?
IntelliJ IDEA 2022.3 is now available with the following updates: 
<ul> 
 <li>New IDE UI available via settings</li> 
 <li>New Settings Sync solution</li> 
 <li>New way to work with projects in WSL2</li> 
 <li>New actions for autowiring Spring beans and generating OpenAPI schemas</li> 
 <li>Redis support</li> 
</ul> Visit our 
<a href="https://www.jetbrains.com/idea/whatsnew/">What's New page</a> to learn about all of the new features and improvements.
    