### PR TITLE
Expand Settings Panel by Default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Added
 
 ### Changed
+- Have the settings panel expanded by default
 
 ### Deprecated
 

--- a/src/main/java/com/chriscarini/jetbrains/locchangecountdetector/settings/SettingsConfigurable.java
+++ b/src/main/java/com/chriscarini/jetbrains/locchangecountdetector/settings/SettingsConfigurable.java
@@ -54,7 +54,7 @@ public class SettingsConfigurable implements Configurable {
                 .getPanel();
 
         final JPanel panel = FormBuilder.createFormBuilder()
-                .addComponent(new CollapsiblePanel(infoTables, true, true, AllIcons.General.ArrowDown,
+                .addComponent(new CollapsiblePanel(infoTables, true, false, AllIcons.General.ArrowDown,
                         AllIcons.General.ArrowRight, Messages.message("loc.settings.configurable.title.threshold.tables")))
                 .getPanel();
 


### PR DESCRIPTION
Its more cumbersome to have to expand the settings panel than to not; we currently don't have anything showing in the settings, so this should be ok for now.