### PR TITLE
Upgrading IntelliJ from 2023.2.2 to 2023.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Added
 
 ### Changed
+- Upgrading IntelliJ from 2023.2.2 to 2023.2.3
 
 ### Deprecated
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@
 pluginGroup = com.chriscarini.jetbrains
 pluginName = 'LoC Change Count Detector'
 # SemVer format -> https://semver.org
-pluginVersion = 0.3.2
+pluginVersion = 0.3.3
 
 ### I DO NOT MAKE USE OF SINCE/UNTIL IN THIS PLUGIN.
 ## See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
@@ -15,7 +15,7 @@ pluginVersion = 0.3.2
 
 # Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl
 # See https://jb.gg/intellij-platform-builds-list for available build versions
-pluginVerifierIdeVersions = 2023.2.2,LATEST-EAP-SNAPSHOT
+pluginVerifierIdeVersions = 2023.2.3,LATEST-EAP-SNAPSHOT
 # Failure Levels: https://github.com/JetBrains/gradle-intellij-plugin/blob/master/src/main/kotlin/org/jetbrains/intellij/tasks/RunPluginVerifierTask.kt
 # Exclude `DEPRECATED_API_USAGES` because we use `CommonCheckinProjectAction` which is a JetBrains internal
 # class that implements a class marked to be deprecated.
@@ -27,7 +27,7 @@ platformType = IC
 # and https://www.jetbrains.com/intellij-repository/snapshots/
 # To use/download EAP add '-EAP-SNAPSHOT' to the version, i.e. 'IU-191.6014.8-EAP-SNAPSHOT'
 #        platformVersion = '201.6668.60-EAP-SNAPSHOT'
-platformVersion = 2023.2.2
+platformVersion = 2023.2.3
 platformDownloadSources = true
 
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html


### PR DESCRIPTION

# Upgrading IntelliJ from 2023.2.2 to 2023.2.3

You can find the change log here: https://youtrack.jetbrains.com/articles/IDEA-A-2100661687/IntelliJ-IDEA-2023.2.3-232.10072.27-build-Release-Notes

# What's New?
IntelliJ IDEA 2023.2.3 is out with the following improvements: 
<ul> 
 <li>The IDE now displays only one Kubernetes context by default, and contexts can be added and removed as needed. This prevents the IDE from freezing due to unnecessary refreshing of all contexts from kubeconfig files. [<a href="https://youtrack.jetbrains.com/issue/IDEA-327422/Idea-tries-to-load-and-refresh-the-context-for-all-Kubernetes-contexts-it-sees-in-kubeconfig">IDEA-327422</a>]</li> 
 <li>The IDE no longer malfunctions when opening some files due to the <em>Access is allowed from Event Dispatch Thread (EDT) only</em> error. [<a href="https://youtrack.jetbrains.com/issue/IDEA-327168">IDEA-327168</a>]</li> 
 <li>The IDE no longer creates redundant GraalVM run configurations for Micronaut projects. [<a href="https://youtrack.jetbrains.com/issue/IDEA-313129">IDEA-313129</a>]</li> 
 <li>Code reformatting works as expected in LightEdit mode. [<a href="https://youtrack.jetbrains.com/issue/IDEA-315522/Unable-to-reformat-file-in-Light-Edit-mode">IDEA-315522</a>]</li> 
</ul> For more details, please refer to this 
<a href="https://blog.jetbrains.com/idea/2023/10/intellij-idea-2023-2-3/">blog post</a>.
    