### PR TITLE
Upgrading IntelliJ from 2023.2.5 to 2023.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Added
 
 ### Changed
+- Upgrading IntelliJ from 2023.2.5 to 2023.3.0
 
 ### Deprecated
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@
 pluginGroup = com.chriscarini.jetbrains
 pluginName = 'LoC Change Count Detector'
 # SemVer format -> https://semver.org
-pluginVersion = 0.3.5
+pluginVersion = 0.4.0
 
 ### I DO NOT MAKE USE OF SINCE/UNTIL IN THIS PLUGIN.
 ## See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
@@ -15,7 +15,7 @@ pluginVersion = 0.3.5
 
 # Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl
 # See https://jb.gg/intellij-platform-builds-list for available build versions
-pluginVerifierIdeVersions = 2023.2.5,LATEST-EAP-SNAPSHOT
+pluginVerifierIdeVersions = 2023.3,LATEST-EAP-SNAPSHOT
 # Failure Levels: https://github.com/JetBrains/gradle-intellij-plugin/blob/master/src/main/kotlin/org/jetbrains/intellij/tasks/RunPluginVerifierTask.kt
 # Exclude `DEPRECATED_API_USAGES` because we use `CommonCheckinProjectAction` which is a JetBrains internal
 # class that implements a class marked to be deprecated.
@@ -27,7 +27,7 @@ platformType = IC
 # and https://www.jetbrains.com/intellij-repository/snapshots/
 # To use/download EAP add '-EAP-SNAPSHOT' to the version, i.e. 'IU-191.6014.8-EAP-SNAPSHOT'
 #        platformVersion = '201.6668.60-EAP-SNAPSHOT'
-platformVersion = 2023.2.5
+platformVersion = 2023.3
 platformDownloadSources = true
 
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html

--- a/src/main/java/com/chriscarini/jetbrains/locchangecountdetector/errorhandler/GitHubErrorReportSubmitter.java
+++ b/src/main/java/com/chriscarini/jetbrains/locchangecountdetector/errorhandler/GitHubErrorReportSubmitter.java
@@ -4,7 +4,6 @@ import com.chriscarini.jetbrains.locchangecountdetector.messages.Messages;
 import com.intellij.ide.troubleshooting.CompositeGeneralTroubleInfoCollector;
 import com.intellij.openapi.application.ApplicationNamesInfo;
 import com.intellij.openapi.application.ex.ApplicationInfoEx;
-import com.intellij.openapi.application.impl.ApplicationInfoImpl;
 import com.intellij.openapi.diagnostic.ErrorReportSubmitter;
 import com.intellij.openapi.diagnostic.IdeaLoggingEvent;
 import com.intellij.openapi.diagnostic.SubmittedReportInfo;
@@ -43,7 +42,7 @@ public class GitHubErrorReportSubmitter extends ErrorReportSubmitter {
             IdeaLoggingEvent @NotNull [] events,
             @Nullable String additionalInfo,
             @NotNull Component parentComponent,
-            @SuppressWarnings("deprecation") @NotNull Consumer<? super SubmittedReportInfo> consumer
+            @NotNull Consumer<? super SubmittedReportInfo> consumer
     ) {
         try {
             final IdeaLoggingEvent event = events.length > 0 ? events[0] : null;
@@ -88,7 +87,7 @@ public class GitHubErrorReportSubmitter extends ErrorReportSubmitter {
     private String generateIssueSummary(@Nullable final String simpleErrorMessage, @NotNull final String stackTrace) {
         final String errorMessage = simpleErrorMessage == null || simpleErrorMessage.isEmpty() ? stackTrace.split("\n\t")[0] : simpleErrorMessage;
 
-        final ApplicationInfoImpl appInfo = (ApplicationInfoImpl) ApplicationInfoEx.getInstanceEx();
+        final ApplicationInfoEx appInfo = ApplicationInfoEx.getInstanceEx();
         final ApplicationNamesInfo applicationNamesInfo = ApplicationNamesInfo.getInstance();
         return String.format(GITHUB_ISSUE_SUMMARY_FORMAT, applicationNamesInfo.getProductName(), appInfo.getFullVersion(), errorMessage);
     }

--- a/src/main/java/com/chriscarini/jetbrains/locchangecountdetector/settings/SettingsConfigurable.java
+++ b/src/main/java/com/chriscarini/jetbrains/locchangecountdetector/settings/SettingsConfigurable.java
@@ -18,6 +18,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import javax.swing.*;
+import java.awt.*;
 
 
 /**
@@ -53,12 +54,13 @@ public class SettingsConfigurable implements Configurable {
                 .addLabeledComponent(new JBLabel(Messages.message("loc.settings.configurable.label.icon.thresholds")), iconInfoTable, true)
                 .getPanel();
 
-        final JPanel panel = FormBuilder.createFormBuilder()
-                .addComponent(new CollapsiblePanel(infoTables, true, false, AllIcons.General.ArrowDown,
-                        AllIcons.General.ArrowRight, Messages.message("loc.settings.configurable.title.threshold.tables")))
-                .getPanel();
-
-        mainPanel.add(panel);
+        if (!GraphicsEnvironment.isHeadless()) {
+            final JPanel panel = FormBuilder.createFormBuilder()
+                    .addComponent(new CollapsiblePanel(infoTables, true, false, AllIcons.General.ArrowDown,
+                            AllIcons.General.ArrowRight, Messages.message("loc.settings.configurable.title.threshold.tables")))
+                    .getPanel();
+            mainPanel.add(panel);
+        }
     }
 
     private void buildChangeThresholdTimeInfoTable() {


### PR DESCRIPTION

# Upgrading IntelliJ from 2023.2.5 to 2023.3.0

You can find the change log here: https://youtrack.jetbrains.com/articles/IDEA-A-2100661779/IntelliJ-IDEA-2023.3-233.11799.241-build-Release-Notes

# What's New?
IntelliJ IDEA 2023.3 is now available with the following new features: 
<ul> 
 <li>AI Assistant, which is now out of preview</li> 
 <li>Full support for Java 21</li> 
 <li><em>Run to Cursor</em> inlay option in the debugger</li> 
 <li>Floating toolbar with editing actions</li> 
 <li>Streamlined out-of-the-box Kubernetes development experience</li> 
</ul> Visit our 
<a href="https://www.jetbrains.com/idea/whatsnew/">What's New page</a> to learn about these and other improvements.
    