### PR TITLE
Upgrading IntelliJ from 2024.2.3 to 2024.2.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Added
 
 ### Changed
+- Upgrading IntelliJ from 2024.2.3 to 2024.2.4
 
 ### Deprecated
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ pluginRepositoryUrl = https://github.com/ChrisCarini/loc-change-count-detector-j
 #   - https://plugins.jetbrains.com/plugins/eap/list
 # Note: You will need to configure the above URL as a custom plugin repository;
 #       see directions: https://www.jetbrains.com/help/idea/managing-plugins.html#repos
-pluginVersion = 1.1.3
+pluginVersion = 1.1.4
 
 ## See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 ## for insight into build numbers and IntelliJ Platform versions.
@@ -17,7 +17,7 @@ pluginUntilBuild = 242.*
 
 # Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl
 # See https://jb.gg/intellij-platform-builds-list for available build versions
-pluginVerifierIdeVersions = 2024.2.3,LATEST-EAP-SNAPSHOT
+pluginVerifierIdeVersions = 2024.2.4,LATEST-EAP-SNAPSHOT
 # Failure Levels: https://github.com/JetBrains/gradle-intellij-plugin/blob/master/src/main/kotlin/org/jetbrains/intellij/tasks/RunPluginVerifierTask.kt
 # Exclude `DEPRECATED_API_USAGES` because we use `CommonCheckinProjectAction` which is a JetBrains internal
 # class that implements a class marked to be deprecated.
@@ -35,7 +35,7 @@ platformType = IC
 #platformVersion = 2024.1.4                     ## 2024.1.4
 #platformVersion = 242.20224.91-EAP-SNAPSHOT    ## 2024.2 Beta
 #platformVersion = 242.20224.159-EAP-SNAPSHOT   ## 2024.2 RC1
-platformVersion = 2024.2.3
+platformVersion = 2024.2.4
 
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
 # Example: platformPlugins = com.jetbrains.php:203.4449.22, org.intellij.scala:2023.3.27@EAP


### PR DESCRIPTION

# Upgrading IntelliJ from 2024.2.3 to 2024.2.4

You can find the change log here: https://youtrack.jetbrains.com/articles/IDEA-A-2100662260/IntelliJ-IDEA-2024.2.4-242.23726.103-build-Release-Notes

# What's New?
IntelliJ IDEA 2024.2.4 is out. This release brings a host of noteworthy fixes and improvements: 
<ul> 
 <li>The Cucumber test tree structure is again properly displayed for Gradle projects in the Run tool window. [<a href="https://youtrack.jetbrains.com/issue/IDEA-356996">IDEA-356996</a>] </li>
 <li>It’s again possible to resize the editor tab pane when it's placed on the left or right side of the editor after the IDE restarts. [<a href="https://youtrack.jetbrains.com/issue/IJPL-161357">IJPL-161357</a>] </li>
 <li>The cursor shape in the terminal now no longer resets to default. [<a href="https://youtrack.jetbrains.com/issue/IJPL-160291">IJPL-160291</a>] </li>
 <li>The IDE now correctly detects TypeScript configuration files for ESLint. [<a href="https://youtrack.jetbrains.com/issue/WEB-68638">WEB-68638</a>] </li>
</ul> Get more details in our 
<a href="https://blog.jetbrains.com/idea/2024/10/intellij-idea-2024-2-4/">blog post</a>.
    