### PR TITLE
Upgrading IntelliJ from 2024.2.4 to 2024.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Added
 
 ### Changed
+- Upgrading IntelliJ from 2024.2.4 to 2024.3.0
 
 ### Deprecated
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,16 +8,16 @@ pluginRepositoryUrl = https://github.com/ChrisCarini/loc-change-count-detector-j
 #   - https://plugins.jetbrains.com/plugins/eap/list
 # Note: You will need to configure the above URL as a custom plugin repository;
 #       see directions: https://www.jetbrains.com/help/idea/managing-plugins.html#repos
-pluginVersion = 1.1.4
+pluginVersion = 1.2.0
 
 ## See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 ## for insight into build numbers and IntelliJ Platform versions.
-pluginSinceBuild = 242
-pluginUntilBuild = 242.*
+pluginSinceBuild = 243
+pluginUntilBuild = 243.*
 
 # Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl
 # See https://jb.gg/intellij-platform-builds-list for available build versions
-pluginVerifierIdeVersions = 2024.2.4,LATEST-EAP-SNAPSHOT
+pluginVerifierIdeVersions = 2024.3,LATEST-EAP-SNAPSHOT
 # Failure Levels: https://github.com/JetBrains/gradle-intellij-plugin/blob/master/src/main/kotlin/org/jetbrains/intellij/tasks/RunPluginVerifierTask.kt
 # Exclude `DEPRECATED_API_USAGES` because we use `CommonCheckinProjectAction` which is a JetBrains internal
 # class that implements a class marked to be deprecated.
@@ -35,7 +35,7 @@ platformType = IC
 #platformVersion = 2024.1.4                     ## 2024.1.4
 #platformVersion = 242.20224.91-EAP-SNAPSHOT    ## 2024.2 Beta
 #platformVersion = 242.20224.159-EAP-SNAPSHOT   ## 2024.2 RC1
-platformVersion = 2024.2.4
+platformVersion = 2024.3
 
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
 # Example: platformPlugins = com.jetbrains.php:203.4449.22, org.intellij.scala:2023.3.27@EAP

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,7 +21,9 @@ pluginVerifierIdeVersions = 2024.3,LATEST-EAP-SNAPSHOT
 # Failure Levels: https://github.com/JetBrains/gradle-intellij-plugin/blob/master/src/main/kotlin/org/jetbrains/intellij/tasks/RunPluginVerifierTask.kt
 # Exclude `DEPRECATED_API_USAGES` because we use `CommonCheckinProjectAction` which is a JetBrains internal
 # class that implements a class marked to be deprecated.
-pluginVerifierExcludeFailureLevels = DEPRECATED_API_USAGES
+# Exclude `OVERRIDE_ONLY_API_USAGES` because we use `CommonCheckinProjectAction` which is apparently marked 
+# with `@ApiStatus.OverrideOnly`.
+pluginVerifierExcludeFailureLevels = DEPRECATED_API_USAGES, OVERRIDE_ONLY_API_USAGES
 # Mute Plugin Problems -> https://github.com/JetBrains/intellij-plugin-verifier?tab=readme-ov-file#check-plugin
 # Used to mute (ignore) a comma-seperated list of plugin problems.
 pluginVerifierMutePluginProblems =

--- a/src/main/java/com/chriscarini/jetbrains/locchangecountdetector/LoCService.java
+++ b/src/main/java/com/chriscarini/jetbrains/locchangecountdetector/LoCService.java
@@ -174,6 +174,17 @@ public class LoCService implements Disposable {
             // Pull up the commit dialog...
             final CommonCheckinProjectAction f = new CommonCheckinProjectAction();
             f.actionPerformed(e);
+//            NOTE: THE BELOW IS A COPY OF THE ABOVE TO AVOID `./gradlew verifyPlugin` FROM FAILING FOR "1 override-only API usage violation". 
+//            WRITTEN & COMMENTED OUT ON 2024-11-14 AND SIMPLY JUST SETTING `OVERRIDE_ONLY_API_USAGES` FOR `verifyPlugin` TASK.  
+//            // The below was pulled from the underlying implementation of `CommonCheckinProjectAction.actionPerformed(e)` on 2024-11-14 to avoid
+//            // `./gradlew verifyPlugin` from failing for "1 override-only API usage violation".
+//            final List<FilePath> roots = Arrays.stream(ProjectLevelVcsManager.getInstance(myProject).getAllVcsRoots())
+//                .filter((it) -> it.getVcs() != null && it.getVcs().getCheckinEnvironment() != null)
+//                .map((it) -> getFilePath(it.getPath()))
+//                .collect(Collectors.toList());
+//            final LocalChangeList initialChangelist = CheckinActionUtil.INSTANCE.getInitiallySelectedChangeList(myProject, e);
+//  
+//            CheckinActionUtil.INSTANCE.performCommonCommitAction(e, myProject, initialChangelist, roots, ActionsBundle.message("action.CheckinProject.text"), null, false);
 
             final Consumer<ChangeInfo> callback = ChangeThresholdService.getInstance(myProject).getCreateCommitActionCallback();
             if (callback != null) {


### PR DESCRIPTION

# Upgrading IntelliJ from 2024.2.4 to 2024.3.0

You can find the change log here: https://youtrack.jetbrains.com/articles/IDEA-A-2100662289/IntelliJ-IDEA-2024.3-243.21565.193-build-Release-Notes

# What's New?
IntelliJ IDEA 2024.3 is out, featuring the following highlights: 
<ul>
 <li><em>Logical</em> code structure view</li>
 <li>Streamlined Kubernetes application debugging</li>
 <li>Cluster-wide Kubernetes log access</li>
 <li>Stable Kotlin K2 mode</li>
</ul> Visit our <a href="https://www.jetbrains.com/idea/whatsnew">What's New page</a> or watch <a href="https://youtu.be/NDBIYcrsC84">this video</a> to learn about these and other improvements.
    