### PR TITLE
Upgrading IntelliJ from 2025.1 to 2025.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Added
 
 ### Changed
+- Upgrading IntelliJ from 2025.1 to 2025.1.1
 
 ### Deprecated
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -17,7 +17,7 @@ pluginUntilBuild = 251.*
 
 # Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl
 # See https://jb.gg/intellij-platform-builds-list for available build versions
-pluginVerifierIdeVersions = 2025.1,LATEST-EAP-SNAPSHOT
+pluginVerifierIdeVersions = 2025.1.1,LATEST-EAP-SNAPSHOT
 # Failure Levels: https://github.com/JetBrains/gradle-intellij-plugin/blob/master/src/main/kotlin/org/jetbrains/intellij/tasks/RunPluginVerifierTask.kt
 pluginVerifierExcludeFailureLevels =
 # Mute Plugin Problems -> https://github.com/JetBrains/intellij-plugin-verifier?tab=readme-ov-file#check-plugin
@@ -33,7 +33,7 @@ platformType = IC
 #platformVersion = 2024.1.4                     ## 2024.1.4
 #platformVersion = 242.20224.91-EAP-SNAPSHOT    ## 2024.2 Beta
 #platformVersion = 242.20224.159-EAP-SNAPSHOT   ## 2024.2 RC1
-platformVersion = 2025.1
+platformVersion = 2025.1.1
 
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
 # Example: platformPlugins = com.jetbrains.php:203.4449.22, org.intellij.scala:2023.3.27@EAP


### PR DESCRIPTION

# Upgrading IntelliJ from 2025.1 to 2025.1.1

You can find the change log here: https://youtrack.jetbrains.com/articles/IDEA-A-2100662429/IntelliJ-IDEA-2025.1.1-251.25410.109-build-Release-Notes

# What's New?
IntelliJ IDEA 2025.1.1 is out! Here are the most notable updates: 
<ul>
 <li>Setting backup and synchronization via <i>Backup and Sync</i> now works as expected upon authorization with JetBrains Account. [<a href="https://youtrack.jetbrains.com/issue/IJPL-183565">IJPL-183565</a>]</li>
 <li>Debugging tests when using Gradle 7.x.x no longer fails. [<a href="https://youtrack.jetbrains.com/issue/IDEA-369597/">IDEA-369597</a>]</li>
 <li>The IDE again correctly imports Maven projects that use several --add-exports arguments. [<a href="https://youtrack.jetbrains.com/issue/IDEA-371005/Maven-Invalid-compiler-parameters-generated-for-multiple-add-exports-in-pom.xml-compilerArgs">IDEA-371005</a>]</li>
 <li>The <i>Paths</i> filter in the <i>Git</i> tool window again works as expected, filtering branches according to the selected repository. [<a href="https://youtrack.jetbrains.com/issue/IJPL-182203/251-Beta-Branches-pane-not-filtered-by-paths-filter-in-the-log-pane">IJPL-182203</a>]</li>
</ul> Get more details from our <a href="https://blog.jetbrains.com/idea/2025/05/intellij-idea-2025-1-1/">blog post</a>.
    