### PR TITLE
Upgrading IntelliJ from 2026.1.4 to 2026.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ## [3.0.2] - 2026-05-16
 
 ### Changed
+- Upgrading IntelliJ from 2026.1.4 to 2026.2
 - Upgrading IntelliJ from 2026.1.3 to 2026.1.4
 - Upgrading IntelliJ from 2026.1.2 to 2026.1.3
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,16 +8,16 @@ pluginRepositoryUrl = https://github.com/ChrisCarini/loc-change-count-detector-j
 #   - https://plugins.jetbrains.com/plugins/eap/list
 # Note: You will need to configure the above URL as a custom plugin repository;
 #       see directions: https://www.jetbrains.com/help/idea/managing-plugins.html#repos
-pluginVersion = 3.0.4
+pluginVersion = 3.1.0
 
 ## See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 ## for insight into build numbers and IntelliJ Platform versions.
-pluginSinceBuild = 261
-pluginUntilBuild = 261.*
+pluginSinceBuild = 262
+pluginUntilBuild = 262.*
 
 # Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl
 # See https://jb.gg/intellij-platform-builds-list for available build versions
-pluginVerifierIdeVersions = 2026.1.4,LATEST-EAP-SNAPSHOT
+pluginVerifierIdeVersions = 2026.2,LATEST-EAP-SNAPSHOT
 # Failure Levels: https://github.com/JetBrains/gradle-intellij-plugin/blob/master/src/main/kotlin/org/jetbrains/intellij/tasks/RunPluginVerifierTask.kt
 pluginVerifierExcludeFailureLevels =
 # Mute Plugin Problems -> https://github.com/JetBrains/intellij-plugin-verifier?tab=readme-ov-file#check-plugin
@@ -31,7 +31,7 @@ pluginVerifierMutePluginProblems =
 #platformVersion = 2024.1.4                     ## 2024.1.4
 #platformVersion = 242.20224.91-EAP-SNAPSHOT    ## 2024.2 Beta
 #platformVersion = 242.20224.159-EAP-SNAPSHOT   ## 2024.2 RC1
-platformVersion = 2026.1.4
+platformVersion = 2026.2
 
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
 # Example: platformPlugins = com.jetbrains.php:203.4449.22, org.intellij.scala:2023.3.27@EAP

--- a/src/main/java/com/chriscarini/jetbrains/locchangecountdetector/LoCService.java
+++ b/src/main/java/com/chriscarini/jetbrains/locchangecountdetector/LoCService.java
@@ -11,6 +11,7 @@ import com.intellij.openapi.Disposable;
 import com.intellij.openapi.actionSystem.ActionManager;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.actionSystem.ex.ActionUtil;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.progress.ProgressIndicator;
 import com.intellij.openapi.progress.ProgressManager;
@@ -176,7 +177,7 @@ public class LoCService implements Disposable {
                 LOG.warn("Unable to find the 'CheckinProject' action.");
                 return;
             }
-            ActionManager.getInstance().tryToExecute(checkinProjectAction, e.getInputEvent(), null, e.getPlace(), true);
+            ActionUtil.performAction(checkinProjectAction, e);
 
             final Consumer<ChangeInfo> callback = ChangeThresholdService.getInstance(myProject).getCreateCommitActionCallback();
             if (callback != null) {

--- a/src/main/java/com/chriscarini/jetbrains/locchangecountdetector/LoCService.java
+++ b/src/main/java/com/chriscarini/jetbrains/locchangecountdetector/LoCService.java
@@ -176,7 +176,7 @@ public class LoCService implements Disposable {
                 LOG.warn("Unable to find the 'CheckinProject' action.");
                 return;
             }
-            checkinProjectAction.actionPerformed(e);
+            ActionManager.getInstance().tryToExecute(checkinProjectAction, e.getInputEvent(), null, e.getPlace(), true);
 
             final Consumer<ChangeInfo> callback = ChangeThresholdService.getInstance(myProject).getCreateCommitActionCallback();
             if (callback != null) {

--- a/src/main/java/com/chriscarini/jetbrains/locchangecountdetector/LoCService.java
+++ b/src/main/java/com/chriscarini/jetbrains/locchangecountdetector/LoCService.java
@@ -8,6 +8,7 @@ import com.intellij.notification.Notification;
 import com.intellij.notification.NotificationGroupManager;
 import com.intellij.notification.NotificationType;
 import com.intellij.openapi.Disposable;
+import com.intellij.openapi.actionSystem.ActionManager;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.diagnostic.Logger;
@@ -19,19 +20,12 @@ import com.intellij.openapi.project.Project;
 import com.intellij.openapi.roots.ProjectRootManager;
 import com.intellij.openapi.util.Disposer;
 import com.intellij.openapi.util.Pair;
-import com.intellij.openapi.vcs.FilePath;
-import com.intellij.openapi.vcs.ProjectLevelVcsManager;
-import com.intellij.openapi.vcs.actions.commit.CheckinActionUtil;
-import com.intellij.openapi.vcs.changes.LocalChangeList;
 import com.intellij.openapi.vfs.VirtualFileManager;
 import com.intellij.openapi.vfs.newvfs.BulkFileListener;
 import com.intellij.openapi.vfs.newvfs.events.VFileEvent;
 import com.intellij.util.ui.update.MergingUpdateQueue;
 import com.intellij.util.ui.update.Update;
-import com.intellij.vcsUtil.VcsUtil;
 import git4idea.commands.GitCommand;
-import java.util.Arrays;
-import java.util.stream.Collectors;
 import org.jetbrains.annotations.NonNls;
 import org.jetbrains.annotations.NotNull;
 
@@ -177,29 +171,12 @@ public class LoCService implements Disposable {
 
         @Override
         public void actionPerformed(@NotNull AnActionEvent e) {
-//            // Pull up the commit dialog...
-//            final CommonCheckinProjectAction f = new CommonCheckinProjectAction();
-//            f.actionPerformed(e);
-//            NOTE: THE ABOVE IS A SHORTHAND OF THE BELOW, BUT ABOVE CAUSES `./gradlew verifyPlugin` TO FAIL FOR "1 override-only API usage violation". 
-//            ~WRITTEN & COMMENTED OUT ON 2024-11-14 AND SIMPLY JUST SETTING `OVERRIDE_ONLY_API_USAGES` FOR `verifyPlugin` TASK.~  
-//            ABOVE WAS COMMENTED OUT ON 2025-01-19 SINCE THE PLUGIN COULD NO LONGER PASS `verifyPlugin` (`OVERRIDE_ONLY_API_USAGES`) TASK.  
-            // The below was pulled from the underlying implementation of `CommonCheckinProjectAction.actionPerformed(e)` on 2024-11-14 to avoid
-            // `./gradlew verifyPlugin` from failing for "1 override-only API usage violation".
-            final List<FilePath> roots = Arrays.stream(ProjectLevelVcsManager.getInstance(myProject).getAllVcsRoots())
-                .filter((it) -> it.getVcs() != null && it.getVcs().getCheckinEnvironment() != null)
-                .map((it) -> VcsUtil.getFilePath(it.getPath()))
-                .collect(Collectors.toList());
-            final LocalChangeList initialChangelist = CheckinActionUtil.INSTANCE.getInitiallySelectedChangeList(myProject, e);
-
-            CheckinActionUtil.INSTANCE.performCommonCommitAction(
-                    e,
-                    myProject,
-                    initialChangelist,
-                    roots,
-                    Messages.message("loc.count.widget.text.commit.action.text"),
-                    null,
-                    false
-            );
+            final AnAction checkinProjectAction = ActionManager.getInstance().getAction("CheckinProject");
+            if (checkinProjectAction == null) {
+                LOG.warn("Unable to find the 'CheckinProject' action.");
+                return;
+            }
+            checkinProjectAction.actionPerformed(e);
 
             final Consumer<ChangeInfo> callback = ChangeThresholdService.getInstance(myProject).getCreateCommitActionCallback();
             if (callback != null) {


### PR DESCRIPTION

# Upgrading IntelliJ from 2026.1.4 to 2026.2

You can find the change log here: https://youtrack.jetbrains.com/articles/IDEA-A-2100662707

# What's New?
<p>IntelliJ IDEA 2026.2 is now out! The highlights of this release include:</p>
<p>AI upgrades:</p>
<ul>
 <li>Native GitHub Copilot integration</li>
 <li>Agent skills</li>
 <li>AI completion support for third-party providers</li>
</ul>
<p>Productivity-enhancing features:</p>
<ul>
 <li>Logpoints</li>
 <li>Dependency completion</li>
 <li>Early Gradle 10 support and migration assistance</li>
 <li>Streamlined Git conflict resolution flow</li>
 <li>Docker Compose improvements</li>
</ul>
<p>Support for new technologies:</p>
<ul>
 <li>Java 27</li>
 <li>Kotlin 2.4 Stable features</li>
 <li>Spring support improvements</li>
 <li>Terraform testing framework</li>
 <li>TypeScript 7.0</li>
</ul>
<p>Visit our <a href="https://www.jetbrains.com/idea/whatsnew/">What's New page</a> to learn about these and other improvements.</p>
    